### PR TITLE
Add MaxRetries support to BrerOptions and related classes

### DIFF
--- a/Brer/Brer.Tests/Core/BrerContextTest.cs
+++ b/Brer/Brer.Tests/Core/BrerContextTest.cs
@@ -18,13 +18,13 @@ public class BrerContextTest
 
         var connectionFactorySub = Substitute.For<IConnectionFactory>();
         var connectionSub = Substitute.For<IConnection>();
-        var modelSub = Substitute.For<IModel>();
+        var modelSub = Substitute.For<IModel>(); 
 
         connectionFactorySub.CreateConnection().Returns(connectionSub);
 
         connectionSub.CreateModel().Returns(modelSub);
 
-        var options = new BrerOptions(connectionFactorySub, "Exchange", "Queue");
+        var options = new BrerOptions(connectionFactorySub, "Exchange", "Queue",null);
 
         // Act
         var res = new BrerContext(options, logger);

--- a/Brer/Brer.Tests/Core/BrerOptionsBuilderTest.cs
+++ b/Brer/Brer.Tests/Core/BrerOptionsBuilderTest.cs
@@ -24,11 +24,11 @@ public class BrerOptionsBuilderTest
         var expectedOptions =
             new BrerOptions(
                 new ConnectionFactory {Port = 123, HostName = "host", UserName = "user", Password = "password"},
-                ExchangeName: "Exchange", QueueName: "Queue");
+                ExchangeName: "Exchange", QueueName: "Queue",4);
 
         // Act
         var res = _sut.WithAddress(host: "host", port: 123).WithExchange("Exchange")
-            .WithQueueName("Queue").WithUsername("user").WithPassword("password").Build();
+            .WithQueueName("Queue").WithUsername("user").WithPassword("password").WithMaxRetries(4).Build();
 
         // Assert
         res.Should().BeEquivalentTo(expectedOptions);
@@ -41,12 +41,12 @@ public class BrerOptionsBuilderTest
         var expectedOptions =
             new BrerOptions(
                 new ConnectionFactory {Port = 5672, HostName = "localhost", UserName = "guest", Password = "guest"},
-                ExchangeName: "Exchange", QueueName: "Queue");
+                ExchangeName: "Exchange", QueueName: "Queue",4);
 
         // Act
         var res = _sut.WithAddress(host: BrerOptionsBuilder.LocalHost, BrerOptionsBuilder.DefaultPort)
             .WithPassword(BrerOptionsBuilder.DefaultLogin).WithUsername(BrerOptionsBuilder.DefaultLogin)
-            .WithExchange("Exchange").WithQueueName("Queue").Build();
+            .WithExchange("Exchange").WithQueueName("Queue").WithMaxRetries(4).Build();
 
         // Assert
         res.Should().BeEquivalentTo(expectedOptions);
@@ -59,7 +59,32 @@ public class BrerOptionsBuilderTest
         var expectedOptions =
             new BrerOptions(
                 new ConnectionFactory {Port = 5672, HostName = "localhost", UserName = "guest", Password = "guest"},
-                ExchangeName: "Exchange", QueueName: "Queue");
+                ExchangeName: "Exchange", QueueName: "Queue",4);
+
+        Environment.SetEnvironmentVariable("BrerHostName", "Host", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("BrerPort", "5672", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("BrerExchangeName", "Exchange", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("BrerQueueName", "Queue", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("BrerUserName", "guest", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("BrerPassword", "guest", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("BrerMaxRetries", "4", EnvironmentVariableTarget.Process);
+
+
+        // Act
+        var res = _sut.ReadFromEnvironmentVariables().Build();
+
+        // Assert
+        res.Should().BeEquivalentTo(expectedOptions);
+    }
+    
+    [Fact]
+    public void ReadFromEnvironmentVariables_Should_Read_Max_Retries_As_Null_When_Not_Present()
+    {
+        // Arrange
+        var expectedOptions =
+            new BrerOptions(
+                new ConnectionFactory {Port = 5672, HostName = "localhost", UserName = "guest", Password = "guest"},
+                ExchangeName: "Exchange", QueueName: "Queue",null);
 
         Environment.SetEnvironmentVariable("BrerHostName", "Host", EnvironmentVariableTarget.Process);
         Environment.SetEnvironmentVariable("BrerPort", "5672", EnvironmentVariableTarget.Process);

--- a/Brer/Brer.Tests/Core/BrerOptionsBuilderTest.cs
+++ b/Brer/Brer.Tests/Core/BrerOptionsBuilderTest.cs
@@ -92,6 +92,7 @@ public class BrerOptionsBuilderTest
         Environment.SetEnvironmentVariable("BrerQueueName", "Queue", EnvironmentVariableTarget.Process);
         Environment.SetEnvironmentVariable("BrerUserName", "guest", EnvironmentVariableTarget.Process);
         Environment.SetEnvironmentVariable("BrerPassword", "guest", EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable("BrerMaxRetries", null, EnvironmentVariableTarget.Process);
 
 
         // Act

--- a/Brer/Brer.Tests/ExtensionMethodsTest.cs
+++ b/Brer/Brer.Tests/ExtensionMethodsTest.cs
@@ -20,7 +20,7 @@ public class ExtensionMethodsTest
         // Arrange
         IServiceCollection services = new ServiceCollection();
 
-        var options = new BrerOptions(new ConnectionFactory(), "exchange", "queue");
+        var options = new BrerOptions(new ConnectionFactory(), "exchange", "queue",4);
 
         // Act
         services.UseBrer(options);

--- a/Brer/Brer.Tests/Listener/BrerListenerTest.cs
+++ b/Brer/Brer.Tests/Listener/BrerListenerTest.cs
@@ -33,7 +33,7 @@ public class BrerListenerTest
 
         _context.Logger.Returns(_logger);
         _context.Connection.Returns(_connection);
-        _context.BrerOptions.Returns(new BrerOptions(Substitute.For<IConnectionFactory>(), "MyExchange", "MyQueue"));
+        _context.BrerOptions.Returns(new BrerOptions(Substitute.For<IConnectionFactory>(), "MyExchange", "MyQueue",10));
         _connection.CreateModel().Returns(_channel);
     }
 

--- a/Brer/Brer.Tests/Publisher/BrerPublisherTest.cs
+++ b/Brer/Brer.Tests/Publisher/BrerPublisherTest.cs
@@ -25,7 +25,7 @@ namespace BrerTests.Publisher
         public BrerPublisherTest()
         {
             _context.Connection.CreateModel().Returns(_model);
-            _context.BrerOptions.Returns(new BrerOptions(Substitute.For<IConnectionFactory>(), _exchangeName, "q"));
+            _context.BrerOptions.Returns(new BrerOptions(Substitute.For<IConnectionFactory>(), _exchangeName, "q",null));
             _logger = Substitute.For<MockLogger<IBrerContext>>();
             _context.Logger.Returns(_logger);
             _sut = new BrerPublisher(_context);

--- a/Brer/Brer/Brer.csproj
+++ b/Brer/Brer/Brer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-        <PackageVersion>1.0.13</PackageVersion>
+        <PackageVersion>1.1.0</PackageVersion>
         <Nullable>enable</Nullable>
         <Title>Brer</Title>
         <Authors>Karmalegend</Authors>

--- a/Brer/Brer/Core/BrerOptions.cs
+++ b/Brer/Brer/Core/BrerOptions.cs
@@ -5,4 +5,5 @@ namespace Brer.Core;
 public record BrerOptions(
     IConnectionFactory Factory,
     string ExchangeName,
-    string QueueName);
+    string QueueName,
+    int? MaxRetries);

--- a/Brer/Brer/Core/BrerOptionsBuilder.cs
+++ b/Brer/Brer/Core/BrerOptionsBuilder.cs
@@ -16,6 +16,7 @@ public class BrerOptionsBuilder
 
     private string RabbitMqUser { get; set; } = null!;
     private string RabbitMqPass { get; set; } = null!;
+    private int? MaxRetries { get; set; }
 
 
     public BrerOptionsBuilder WithAddress(string host, int port)
@@ -49,6 +50,18 @@ public class BrerOptionsBuilder
         return this;
     }
 
+    /// <summary>
+    /// When this number is hit the message gets nacked Brer assumes you've properly setup a DLX.
+    /// The message gets queued with x-first-death-reason set as rejected.
+    /// </summary>
+    /// <param name="maxRetries"></param>
+    /// <returns></returns>
+    public BrerOptionsBuilder WithMaxRetries(int maxRetries)
+    {
+        MaxRetries = maxRetries;
+        return this;
+    }
+
     public BrerOptionsBuilder ReadFromEnvironmentVariables()
     {
         Host = Environment.GetEnvironmentVariable("BrerHostName") ?? throw new ArgumentNullException(nameof(Host));
@@ -62,6 +75,11 @@ public class BrerOptionsBuilder
                        throw new ArgumentNullException(nameof(RabbitMqUser));
         RabbitMqPass = Environment.GetEnvironmentVariable("BrerPassword") ??
                        throw new ArgumentNullException(nameof(RabbitMqPass));
+        
+        MaxRetries = int.TryParse(Environment.GetEnvironmentVariable("BrerMaxRetries"), out var parsedRetries)
+            ? parsedRetries
+            : null;
+        
         return this;
     }
 
@@ -75,6 +93,7 @@ public class BrerOptionsBuilder
                 Password = RabbitMqPass
             },
             ExchangeName,
-            QueueName);
+            QueueName,
+            MaxRetries);
     }
 }

--- a/Brer/Brer/Core/BrerOptionsBuilder.cs
+++ b/Brer/Brer/Core/BrerOptionsBuilder.cs
@@ -51,7 +51,7 @@ public class BrerOptionsBuilder
     }
 
     /// <summary>
-    /// When this number is hit the message gets nacked Brer assumes you've properly setup a DLX.
+    /// When this number is hit, the message gets nacked Brer creates the DLX exchange and queue according to the readme
     /// The message gets queued with x-first-death-reason set as rejected.
     /// </summary>
     /// <param name="maxRetries"></param>

--- a/Brer/Brer/Listener/BrerListener.cs
+++ b/Brer/Brer/Listener/BrerListener.cs
@@ -36,7 +36,14 @@ internal sealed class BrerListener : IBrerListener
     {
         _channel = _context.Connection.CreateModel();
         _channel.ExchangeDeclare(exchange: _context.BrerOptions.ExchangeName, type: ExchangeType.Topic);
-        _channel.QueueDeclare(queue: _context.BrerOptions.QueueName, true, false, false);
+        
+         var arguments = new Dictionary<string, object>
+         {
+             {"x-dead-letter-exchange", _context.BrerOptions.ExchangeName + "-dlx"},
+             {"x-dead-letter-routing-key", _context.BrerOptions.QueueName + "-dlx"}
+         };
+
+        _channel.QueueDeclare(queue: _context.BrerOptions.QueueName, true, false, false,arguments);
         foreach (var topic in _topics)
         {
             _context.Logger.LogInformation(

--- a/Brer/Brer/Listener/Interfaces/IBrerListenerBuilder.cs
+++ b/Brer/Brer/Listener/Interfaces/IBrerListenerBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Brer.Listener.Runtime;
 
 namespace Brer.Listener.Interfaces;
 

--- a/Examples/MvcExample/Startup.cs
+++ b/Examples/MvcExample/Startup.cs
@@ -28,6 +28,7 @@ namespace MVCListenerHostedService
                     .WithUsername(BrerOptionsBuilder.DefaultLogin)
                     .WithExchange("MyExchange")
                     .WithQueueName("MyQueue")
+                    .WithMaxRetries(3)
                     .Build()
                 );
         }

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ or use ```WithMaxRetries(5)``` Brer does not try to infer any dlx naming or allo
 
 It will always use the provided exchange and queue name for dlx routing f.e.:
 
-**important** to note Brer will create the (persistent) queue for you but __*NOT*__ the exchange
+**important** to note Brer will create the (persistent) queue for you but __*NOT*__ the exchange if you do not make sure
+the Exchange exists before-hand messages will silently be dropped.
 
 | Brer Variable    | Name                | DLX Name                | RabbitmqHeader            |
 |------------------|---------------------|-------------------------|---------------------------|

--- a/README.md
+++ b/README.md
@@ -127,9 +127,7 @@ public class MyEventPublisher{
 ```
 
 ## Error handling.
-
-Brer currently does not support DLX or 'poison queues' brer does however add some message headers to give insights into
-exceptions and requeue counts.
+Brer adds some message headers to give insights into exceptions and requeue counts.
 
 These headers are:
 
@@ -138,6 +136,8 @@ These headers are:
 * `x-Brer-Exception-StackTrace`
 * `x-Brer-RequeueCount`
 
+Note: that these get overwritten if an error gets thrown again whilst re-processing.
+
 ### DLX (Dead Letter Exchange) / Poison Queue
 
 Brer can be configured to send messages to a DLX one can either provide the env var `BrerMaxRetries` when using env vars
@@ -145,8 +145,8 @@ or use ```WithMaxRetries(5)``` Brer does not try to infer any dlx naming or allo
 
 It will always use the provided exchange and queue name for dlx routing f.e.:
 
-**important** to note Brer will create the (persistent) queue for you but __*NOT*__ the exchange if you do not make sure
-the Exchange exists before-hand messages will silently be dropped.
+**important** to note Brer will create the (persistent) queue for you but __*AND*__ the exchange if you do not make sure
+the user has correct permissions before-hand messages will be dropped.
 
 | Brer Variable    | Name                | DLX Name                | RabbitmqHeader            |
 |------------------|---------------------|-------------------------|---------------------------|

--- a/README.md
+++ b/README.md
@@ -8,25 +8,26 @@ __Special thanks to Marco Pil__
 
 - [Brer](#brer)
 - [How do i use Brer?](#how-do-i-use-brer)
-  - [Initial Setup](#initial-setup)
-  - [Registering/Decorating an EventListener](#registeringdecorating-an-eventlistener)
-      - [Handler](#handler)
-      - [WildCardHandler](#wildcardhandler)
-  - [Publishing events.](#publishing-events)
-  - [Error handling.](#error-handling)
+    - [Initial Setup](#initial-setup)
+    - [Registering/Decorating an EventListener](#registeringdecorating-an-eventlistener)
+        - [Handler](#handler)
+        - [WildCardHandler](#wildcardhandler)
+    - [Publishing events.](#publishing-events)
+    - [Error handling.](#error-handling)
 - [I want to contribute!](#i-want-to-contribute)
 - [I'm missing a feature!](#im-missing-a-feature)
 
-
 # How do i use Brer?
-Brer makes use of a [hostedservice](https://learn.microsoft.com/en-us/dotnet/core/extensions/timer-service?pivots=dotnet-6-00) in ASP.NET.
 
+Brer makes use of
+a [hostedservice](https://learn.microsoft.com/en-us/dotnet/core/extensions/timer-service?pivots=dotnet-6-00) in ASP.NET.
 
 A basic brer startup example can be found [here](https://github.com/karmalegend/Brer/tree/main/Brer/Example%20Project).
 
 ## Initial Setup
 
 In short one must register the Brer services as follows:
+
 ```C#
 services.UseBrer(
     new BrerOptionsBuilder().WithAddress(BrerOptionsBuilder.localHost, BrerOptionsBuilder.defaultPort)
@@ -39,26 +40,32 @@ services.UseBrer(
 ```
 
 Brer can also be configured using environment variables as follows:
+
 ```C#
 services.UseBrer(new BrerOptionsBuilder().ReadFromEnviromentVariables().Build());
 ```
+
 Where it will look for the following variables:
+
 * `BrerHostName`
 * `BrerPort`
 * `BrerExchangeName`
 * `BrerQueueName`
 * `BrerUserName`
 * `BrerPassword`
-
+* Optionally : `BrerMaxRetries` [see DLX in Brer](#dlx-dead-letter-exchange--poison-queue)
 
 ## Registering/Decorating an EventListener
+
 Brer will automatically scan all referencing assemblies for EventListeners.
 
-Once a class is annoted with the ```EventListener``` attribute it will further scan the class for ```Handler``` or ```WildCardHandler```.
+Once a class is annoted with the ```EventListener``` attribute it will further scan the class for ```Handler``` or
+```WildCardHandler```.
 
 If Listeners collide on topic names ```Handler``` will always take priority over ```WildCardHandler```.
 
 #### Handler
+
 ```C#
 [EventListener]
 public class MyEventHandler{
@@ -71,22 +78,22 @@ public class MyEventHandler{
 }
 ```
 
-
 #### WildCardHandler
 
 When using a WildCardHandler you're **required** to use at least 1 wild card in the topic binding.
 
 Wild cards can contain as many * as wanted but impose some restrictions on the usage of #.
-Only 1 # can be used somewhere in the middle of a topic name and 1 the end. if you require more it's likely best to re-evaluate the topic naming or simply use *.
+Only 1 # can be used somewhere in the middle of a topic name and 1 the end. if you require more it's likely best to
+re-evaluate the topic naming or simply use *.
 
 A valid format would be:
+
 * ```MyGarage*.Rental.Cars.#.Internal.*.#```
 * ```#```
 * etc
 
 An invalid format would be:
 ```MyGarage.#.Cars.#.Internal.*.#``` We use two #'s in the middle of the topic here which is not allowed.
-
 
 ```C#
 [EventListener]
@@ -100,10 +107,10 @@ public class MyEventHandler{
 }
 ```
 
-
 ## Publishing events.
 
 To publish an event simply inject the ```IBrerPublisher``` into your class.
+
 ```C#
 public class MyEventPublisher{
 
@@ -120,29 +127,42 @@ public class MyEventPublisher{
 ```
 
 ## Error handling.
+
 Brer currently does not support DLX or 'poison queues' brer does however add some message headers to give insights into
 exceptions and requeue counts.
 
 These headers are:
+
 * `x-Brer-Exception`
 * `x-Brer-Exception-Message`
 * `x-Brer-Exception-StackTrace`
 * `x-Brer-RequeueCount`
 
-Using these headers, you could add your own DLX / poison queue logic f.e. by checking the requeue count and if it's above
-3 sending it to a poison queue. Just make sure you preserve the other headers, to make debugging & tracing a lot easier.
+### DLX (Dead Letter Exchange) / Poison Queue
 
+Brer can be configured to send messages to a DLX one can either provide the env var `BrerMaxRetries` when using env vars
+or use ```WithMaxRetries(5)``` Brer does not try to infer any dlx naming or allowing for customization.
+
+It will always use the provided exchange and queue name for dlx routing f.e.:
+
+**important** to note Brer will create the (persistent) queue for you but __*NOT*__ the exchange
+
+| Brer Variable    | Name                | DLX Name                | RabbitmqHeader            |
+|------------------|---------------------|-------------------------|---------------------------|
+| BrerExchangeName | my-company-exchange | my-company-exchange-dlx | x-dead-letter-exchange    |
+| BrerQueueName    | my-service-queue    | my-service-queue-dlx    | x-dead-letter-routing-key | 
 
 # I want to contribute!
-As of now we'd greatly appreciate adding support for different exchange types. And adding dlx support 
-/ requeue-ing messages from a dlx.
 
-notes: 
+As of now we'd greatly appreciate adding support for different exchange types.
+
+notes:
+
 - No global usings
 - Use SonarLint
 - Rider/ReSharper default styling preferred
 
-
 # I'm missing a feature!
+
 [Simply open an issue](https://github.com/karmalegend/Brer/issues)
 


### PR DESCRIPTION
Add MaxRetries property to BrerOptions and related builders to control retry behavior. Update BrerListener to nack messages after exceeding MaxRetries, and include corresponding tests and documentation updates.